### PR TITLE
Prevent header from hiding top of section on jump to target anchor

### DIFF
--- a/src/sass/_theme_layout.sass
+++ b/src/sass/_theme_layout.sass
@@ -525,6 +525,12 @@ footer
         position: relative
         top: 1px
 
+*:target::before
+  content: ""
+  display: block
+  height: 71px
+  margin: -71px 0 0
+
 @media screen and (max-width: 920px)
   .wy-main-nav li + li
     margin-left: 0
@@ -596,3 +602,6 @@ footer
 // seems to do the trick, haven't noticed any visual regressions with tables 
 .rst-content table.docutils td:first-child
   border-left-width: 1px
+
+  *:target::before
+    display: none


### PR DESCRIPTION
The theme provides anchors to jump directly to a given section on a page (From URL or from the “Permalink to this headline” buttons). When jumping with it, the top of the target section is hidden under the header banner.

This is an attempt to fix it by adding a hidden block of the same height of the `.wy-header` class elements (70px + 1px padding) before the targets. Hide it when the page is less than 790px wide (since the header is hidden too).

The fix is based after [this post from Stack Overflow](https://stackoverflow.com/a/28824157/3716552) (which also illustrates the problem in the question).
