### PR TITLE
layout: Twitter summary card

### DIFF
--- a/sphinx_rtd_theme/layout.html
+++ b/sphinx_rtd_theme/layout.html
@@ -112,6 +112,11 @@
   {%- endif %}
   {%- endblock %}
   {%- block extrahead %} {% endblock %}
+
+  <meta name="twitter:card" content="summary"/>
+  <meta name="twitter:site" content="@ciliumproject"/>
+  <meta name="twitter:title" content="{{ title|striptags|e }}{{ titlesuffix }}"/>
+  <meta name="twitter:image" content="{{ canonical_url }}{{ pathto('_static/' + logo, 1) }}"/>
 </head>
 
 <body class="wy-body-for-nav">


### PR DESCRIPTION
This pull request attempts to add a summary card for Twitter, to get a basic preview with the title and logo.