### PR TITLE
Fix typo on .rst-current-version-label class name

### DIFF
--- a/sphinx_rtd_theme/versions.html
+++ b/sphinx_rtd_theme/versions.html
@@ -2,7 +2,7 @@
 {# Add rst-badge after rst-versions for small badge style. #}
   <div class="rst-versions" data-toggle="rst-versions" role="note" aria-label="{{ _('Versions') }}">
     <span class="rst-current-version" data-toggle="rst-current-version">
-      <span class="ret-current-version-label"> Read the Docs</span>
+      <span class="rst-current-version-label"> Read the Docs</span>
       version: {{ current_version }}
       <span class="fa fa-caret-down"></span>
     </span>


### PR DESCRIPTION
When rebasing from branch v0.7 on top of upstream to create branch v1.0, a typo was introduced on a class name. As a result, the "Read the Docs" label in the bottom-left corner of the HTML pages are not styled properly (it misses a heavier font and it should float to the left). Let's fix the typo.