### PR TITLE
Fix hidden search bar on all media types

### DIFF
--- a/src/sass/_theme_layout.sass
+++ b/src/sass/_theme_layout.sass
@@ -485,6 +485,10 @@ footer
     position: relative
     +media($mobile)
 
+  @media (max-width: 1169px)
+    .wy-github-stars
+      display: none
+
   .wy-header-logo-wrapper
     min-width: 119px
 


### PR DESCRIPTION
On certain viewport sizes, an increased `.wy-header` height caused the **Github Stars** and **Join Slack** buttons in `.wy-github-stars` to overlap the search bar. These buttons would either partially overlap the search bar and breadcrumbs, or completely overlap the left hamburger menu, which contains the search bar when expanded.

This adds a media query to hide the two buttons when the viewport width is 1169px or less.

____________________

I tested this using **Webpack Dev Server** for live development. I also used **Chrome DevTools' Device Mode** to simulate different devices. Cross-browser tests include Google Chrome, Mozilla Firefox, and Safari. 

Fixes: [#21938](https://github.com/cilium/cilium/issues/21938).
